### PR TITLE
chore(gitignore): Airによる更新を無視

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,13 @@
+# Air / Go build artifacts
+tmp/
+build/
+bin/
+build-errors.log
+
+# Go test cache / coverage
+*.out
+*.test
+
+# OS/IDE
+.DS_Store
+.vscode/


### PR DESCRIPTION
## 目的
backend側のgitignoreの更新

## 具体的な変更点・新規実装点
backend/tmp/main がリポジトリで“追跡対象”になっていて、ローカルで内容が変わってしまうため、gitignoreに設定し無効化

## 動作確認
特になし